### PR TITLE
Only attempt to redact and upload logs, if TF plan fails

### DIFF
--- a/.github/workflows/tf-merge.yml
+++ b/.github/workflows/tf-merge.yml
@@ -73,8 +73,8 @@ jobs:
           AWS_DEFAULT_REGION: eu-west-2
 
       - name: "Redact Logs PROD"
-        if: failure()
-        id: redact-logs-mgmt
+        if: steps.plan.conclusion == 'failure'
+        id: redact-logs-prod
         run: |
               sed -i "s/$ACC_PROD/REDACTED/g" ${{ github.workspace }}/${{ github.run_id }}-${{ github.run_number }}.log
         shell: bash
@@ -82,7 +82,7 @@ jobs:
           ACC_PROD: ${{ secrets.AWS_GHA_ACC_PROD }}
 
       - uses: actions/upload-artifact@v2
-        if: failure()
+        if: steps.redact-logs-prod.conclusion == 'failure'
         with:
           name: prod-workflow-log
           path: ${{ github.workspace }}/${{ github.run_id }}-${{ github.run_number }}.log

--- a/.github/workflows/tf-merge.yml
+++ b/.github/workflows/tf-merge.yml
@@ -82,7 +82,7 @@ jobs:
           ACC_PROD: ${{ secrets.AWS_GHA_ACC_PROD }}
 
       - uses: actions/upload-artifact@v2
-        if: steps.redact-logs-prod.conclusion == 'failure'
+        if: steps.redact-logs-prod.conclusion == 'success'
         with:
           name: prod-workflow-log
           path: ${{ github.workspace }}/${{ github.run_id }}-${{ github.run_number }}.log

--- a/.github/workflows/tf-pull-request.yml
+++ b/.github/workflows/tf-pull-request.yml
@@ -61,7 +61,7 @@ jobs:
           AWS_DEFAULT_REGION: eu-west-2
 
       - name: "Redact Logs PROD PR"
-        if: failure()
+        if: steps.plan.conclusion == 'failure'
         id: redact-logs-prod-pr
         run: |
               sed -i "s/$ACC_PROD/REDACTED/g" ${{ github.workspace }}/${{ github.run_id }}-${{ github.run_number }}.log
@@ -70,7 +70,7 @@ jobs:
           ACC_PROD: ${{ secrets.AWS_GHA_ACC_PROD }}
 
       - uses: actions/upload-artifact@v2
-        if: failure()
+        if: steps.redact-logs-prod-pr.conclusion == 'success'
         with:
           name: prod-workflow-log
           path: ${{ github.workspace }}/${{ github.run_id }}-${{ github.run_number }}.log


### PR DESCRIPTION
Proposed fix to only attempt redaction and upload steps, if the TF plan step fails.  Removes confusion should steps before fail, causing these steps to file due to the log file not existing.